### PR TITLE
Add read index privilege to synth integration

### DIFF
--- a/packages/synthetics/data_stream/browser/manifest.yml
+++ b/packages/synthetics/data_stream/browser/manifest.yml
@@ -13,6 +13,7 @@ elasticsearch:
         sort.field:
           - "url.full.keyword"
           - "monitor.id"
+  privileges.indices: [auto_configure, create_doc, read]
 streams:
   - input: synthetics/browser
     title: Synthetic monitor check

--- a/packages/synthetics/data_stream/browser_network/manifest.yml
+++ b/packages/synthetics/data_stream/browser_network/manifest.yml
@@ -15,6 +15,7 @@ elasticsearch:
           - "http.request.url.keyword"
           - "http.response.headers.etag"
           - "monitor.id"
+  privileges.indices: [auto_configure, create_doc, read]
 streams:
   - input: synthetics/browser
     title: Synthetics monitors network information

--- a/packages/synthetics/data_stream/browser_screenshot/manifest.yml
+++ b/packages/synthetics/data_stream/browser_screenshot/manifest.yml
@@ -12,6 +12,7 @@ elasticsearch:
         codec: best_compression
         sort.field:
           - "monitor.id"
+  privileges.indices: [auto_configure, create_doc, read]
 streams:
   - input: synthetics/browser
     title: Synthetics monitors screenshot information

--- a/packages/synthetics/data_stream/http/manifest.yml
+++ b/packages/synthetics/data_stream/http/manifest.yml
@@ -13,6 +13,7 @@ elasticsearch:
         sort.field:
           - "monitor.id"
           - "url.full.keyword"
+  privileges.indices: [auto_configure, create_doc, read]
 streams:
   - input: synthetics/http
     title: Synthetic monitor check

--- a/packages/synthetics/data_stream/icmp/manifest.yml
+++ b/packages/synthetics/data_stream/icmp/manifest.yml
@@ -13,6 +13,7 @@ elasticsearch:
         sort.field:
           - "monitor.id"
           - "url.full.keyword"
+  privileges.indices: [auto_configure, create_doc, read]
 streams:
   - input: synthetics/icmp
     title: Synthetic monitor check

--- a/packages/synthetics/data_stream/tcp/manifest.yml
+++ b/packages/synthetics/data_stream/tcp/manifest.yml
@@ -13,6 +13,7 @@ elasticsearch:
         sort.field:
           - "monitor.id"
           - "url.full.keyword"
+  privileges.indices: [auto_configure, create_doc, read]
 streams:
   - input: synthetics/tcp
     title: Synthetic monitor check


### PR DESCRIPTION
Add read index privilege to private location policy.

Works together with https://github.com/elastic/beats/pull/33405.

The easiest way I've found to test this locally:
1. Build the integration spec and run `elastic-package stack up`
2. Log into Kibana and create a private location policy.
3. Create a private location assigned to the policy and add a few monitors.
4. In Fleet, copy policy yaml. Save this to a file and update the output section to point to a CFT url and user.
5. Run `elastic-agent` container with the standalone policy and local version of heartbeat:
```bash
docker run --rm \ 
-v <beats repo>/x-pack/heartbeat:/usr/share/elastic-agent/data/elastic-agent-edc1e8/install/heartbeat-8.6.0-linux-x86_64 \ 
-v /tmp/agent.yaml:/usr/share/elastic-agent/elastic-agent.yml -it docker.elastic.co/beats/elastic-agent-complete:8.6.0
```